### PR TITLE
Add null check in `OutOfSight#getCanonicalName`

### DIFF
--- a/src/main/java/com/corosus/out_of_sight/OutOfSight.java
+++ b/src/main/java/com/corosus/out_of_sight/OutOfSight.java
@@ -43,7 +43,11 @@ public class OutOfSight
 
     public static String getCanonicalNameCached(Class clazz) {
         if (!cacheClassToCanonicalName.containsKey(clazz)) {
-            cacheClassToCanonicalName.put(clazz, clazz.getCanonicalName());
+            String canonicalName = clazz.getCanonicalName();
+            if (canonicalName == null) {
+                canonicalName = "";
+            }
+            cacheClassToCanonicalName.put(clazz, canonicalName);
         }
         return cacheClassToCanonicalName.get(clazz);
     }


### PR DESCRIPTION
The `OutOfSight#getCanonicalName` method returns the canonical name of the given class. Specifically, `Class#getCanonicalName` is cached and returned. As per the javadoc, the result of `Class#getCanonicalName` may be `null` for local, anonymous, or hidden classes. This means that the result of `OutOfSight#getCanonicalName` will also be null for those cases.

Everywhere `OutOfSight#getCanonicalName` is called, `String#startsWith` is immediately called on its return value. This leads to an exception whenever the result of `OutOfSight#getCanonicalName` is null.

Currently, the only use case for `OutOfSight#getCanonicalName` is to check if a certain class is in the `net.minecraft` package. Since the cases mentioned above don't occur for any of Minecraft's classes anyways, I've opted to return an empty string whenever `Class#getCanonicalName` is null.
```diff
-         cacheClassToCanonicalName.put(clazz, clazz.getCanonicalName());
+         String canonicalName = clazz.getCanonicalName();
+         if (canonicalName == null) {
+             canonicalName = "";
+         }
+         cacheClassToCanonicalName.put(clazz, canonicalName);
```

Relevant issues:
This seems to cause issues for nearly all my mods (#13, #12, https://github.com/SuperMartijn642/WirelessChargers/issues/21) and also for some other mods, such as ElementalCraft (#6).
I keep getting issue reports from this, so hopefully it can be solved either through this PR or through some other solution 🙂